### PR TITLE
Add background colors for Find + Replace matches

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -7,7 +7,7 @@
 
 atom-text-editor[mini] {
   padding-left: @component-padding/2;
-  color: @text-color;
+  color: white;
   border-radius: @component-border-radius;
   background-color: @input-background-color;
 

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -11,7 +11,9 @@
 
 .match,
 .replacement,
-.highlight-info {
+.highlight-info,
+.highlight-error,
+.highlight-success {
   color: black;
   margin: 0 2px;
 }

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -26,4 +26,5 @@
 
 .highlight-success {
   background: @text-color-success;
+  margin-left: 0;
 }

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -8,3 +8,22 @@
 .find-and-replace {
   border-top: 1px solid @base-border-color;
 }
+
+.match,
+.replacement,
+.highlight-info {
+  color: black;
+  margin: 0 2px;
+}
+
+.highlight-info {
+  background: white;
+}
+
+.highlight-error {
+  background: @text-color-error;
+}
+
+.highlight-success {
+  background: @text-color-success;
+}


### PR DESCRIPTION
Fixes issue #4.

I love the contrast of this theme and I've been using it since you guys announced it. Nice work! I noticed that this theme lacks some styles in the Find + Replace screen. Here's a PR that takes a stab at using Framer's brand colors to highlight find + replace matches.

This PR Add some helpful background colors for:
- highlighting search terms in the results list
- highlighting the term that will be replaced
- highlighting the new term that will be used as the replacement

It also updates the text color to white for Find + Replace text input values.

### Screenshots
#### Before:
![](http://kpnsk.me/rJ84/Screen%20Shot%202018-05-02%20at%202.16.21%20PM.png)
_Find in Buffer_

![](http://kpnsk.me/rJJu/Screen%20Shot%202018-05-02%20at%202.16.27%20PM.png)
_Find in Project_

![](http://kpnsk.me/rJHr/Screen%20Shot%202018-05-02%20at%202.16.35%20PM.png)
_Find + Replace in Buffer_

![](http://kpnsk.me/rJ4F/Screen%20Shot%202018-05-02%20at%202.16.40%20PM.png)
_Find + Replace in Project_

#### After:
![](http://kpnsk.me/rJNC/Screen%20Shot%202018-05-02%20at%202.12.37%20PM.png)
_Find in Buffer_

![](http://kpnsk.me/rJGw/Screen%20Shot%202018-05-02%20at%202.13.00%20PM.png)
_Find in Project_

![](http://kpnsk.me/rJFt/Screen%20Shot%202018-05-02%20at%202.17.58%20PM.png)
_Find + Replace in Buffer_

![](http://kpnsk.me/rJSQ/Screen%20Shot%202018-05-02%20at%202.18.02%20PM.png)
_Find + Replace in Project_